### PR TITLE
Reference type deduction, Reduce storage to a single pointer, 0 copy reference yielding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,6 @@ target_include_directories(stdgenerator
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>)
 
 target_compile_features(stdgenerator INTERFACE cxx_std_20)
-target_compile_options(stdgenerator INTERFACE -fcoroutines)
 
 enable_testing()
 include(CTest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ target_include_directories(stdgenerator
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>)
 
 target_compile_features(stdgenerator INTERFACE cxx_std_20)
+target_compile_options(stdgenerator INTERFACE -fcoroutines)
 
 enable_testing()
 include(CTest)

--- a/include/__generator.hpp
+++ b/include/__generator.hpp
@@ -13,6 +13,7 @@
 // (See accompanying file LICENSE or http://www.boost.org/LICENSE_1_0.txt)
 ///////////////////////////////////////////////////////////////////////////////
 
+#include <memory>
 #pragma once
 
 #if __has_include(<coroutine>)
@@ -141,81 +142,7 @@ concept range = requires(_T& __t) {
 
 namespace std {
 
-template <typename _T>
-class __manual_lifetime {
-  public:
-    __manual_lifetime() noexcept {}
-    ~__manual_lifetime() {}
-
-    template <typename... _Args>
-    _T& construct(_Args&&... __args) noexcept(std::is_nothrow_constructible_v<_T, _Args...>) {
-        return *::new (static_cast<void*>(std::addressof(__value_))) _T((_Args&&)__args...);
-    }
-
-    void destruct() noexcept(std::is_nothrow_destructible_v<_T>) {
-        __value_.~_T();
-    }
-
-    _T& get() & noexcept {
-        return __value_;
-    }
-    _T&& get() && noexcept {
-        return static_cast<_T&&>(__value_);
-    }
-    const _T& get() const & noexcept {
-        return __value_;
-    }
-    const _T&& get() const && noexcept {
-        return static_cast<const _T&&>(__value_);
-    }
-
-  private:
-    union {
-        std::remove_const_t<_T> __value_;
-    };
-};
-
-template <typename _T>
-class __manual_lifetime<_T&> {
-  public:
-    __manual_lifetime() noexcept : __value_(nullptr) {}
-    ~__manual_lifetime() {}
-
-    _T& construct(_T& __value) noexcept {
-        __value_ = std::addressof(__value);
-        return __value;
-    }
-
-    void destruct() noexcept {}
-
-    _T& get() const noexcept {
-        return *__value_;
-    }
-
-  private:
-    _T* __value_;
-};
-
-template <typename _T>
-class __manual_lifetime<_T&&> {
-  public:
-    __manual_lifetime() noexcept : __value_(nullptr) {}
-    ~__manual_lifetime() {}
-
-    _T&& construct(_T&& __value) noexcept {
-        __value_ = std::addressof(__value);
-        return static_cast<_T&&>(__value);
-    }
-
-    void destruct() noexcept {}
-
-    _T&& get() const noexcept {
-        return static_cast<_T&&>(*__value_);
-    }
-
-  private:
-    _T* __value_;
-};
+struct use_allocator_arg {};
 
 struct use_allocator_arg {};
 
@@ -342,8 +269,8 @@ struct __generator_promise_base
     // generator coroutine is not used as a nested coroutine).
     // This member is lazily constructed by the __yield_sequence_awaiter::await_suspend()
     // method if this generator is used as a nested generator.
-    __manual_lifetime<std::exception_ptr> __exception_;
-    __manual_lifetime<_Ref> __value_;
+    std::exception_ptr __exception_;
+    std::add_pointer_t<std::remove_reference_t<_Ref>> __value_;
 
     explicit __generator_promise_base(std::coroutine_handle<> thisCoro) noexcept
         : __root_(this)
@@ -351,12 +278,6 @@ struct __generator_promise_base
     {}
 
     ~__generator_promise_base() {
-        if (__root_ != this) {
-            // This coroutine was used as a nested generator and so will
-            // have constructed its __exception_ member which needs to be
-            // destroyed here.
-            __exception_.destruct();
-        }
     }
 
     std::suspend_always initial_suspend() noexcept {
@@ -367,7 +288,7 @@ struct __generator_promise_base
 
     void unhandled_exception() {
         if (__root_ != this) {
-            __exception_.get() = std::current_exception();
+            __exception_ = std::current_exception();
         } else {
             throw;
         }
@@ -399,21 +320,39 @@ struct __generator_promise_base
         return {};
     }
 
-    std::suspend_always yield_value(_Ref&& __x)
-            noexcept(std::is_nothrow_move_constructible_v<_Ref>) {
-        __root_->__value_.construct((_Ref&&)__x);
+
+    std::suspend_always yield_value(_Ref __x)
+    requires std::is_lvalue_reference_v<_Ref>
+    {
+        __root_->__value_ = std::addressof(__x);
         return {};
     }
 
-    template <typename _T>
-    requires
-        (!std::is_reference_v<_Ref>) &&
-        std::is_convertible_v<_T, _Ref>
-    std::suspend_always yield_value(_T&& __x)
-            noexcept(std::is_nothrow_constructible_v<_Ref, _T>) {
-        __root_->__value_.construct((_T&&)__x);
-        return {};
-    }
+    template <typename T>
+    auto yield_value(T&& __x)
+    noexcept(std::is_nothrow_constructible_v<_Ref, T>)
+    requires is_constructible_v<_Ref, T>
+
+    {
+        struct awaiter : std::suspend_always {
+            std::remove_reference_t<_Ref> __value;
+            std::exception_ptr __exception;
+
+
+            awaiter(__generator_promise_base* __this, T&& __t) : __value((T&&)__t) {
+                __this->__root_->__value_ = std::addressof(__value);
+            }
+            awaiter(const awaiter&&) = delete;
+            awaiter(awaiter&&) = delete;
+
+            void await_resume() {
+                if (__exception) {
+                    std::rethrow_exception(std::move(__exception));
+                }
+            }
+        };
+        return awaiter(this, (T&&)(__x));
+    };
 
     template <typename _Gen>
     struct __yield_sequence_awaiter {
@@ -440,11 +379,6 @@ struct __generator_promise_base
 
             __nested.__root_ = __current.__root_;
             __nested.__parentOrLeaf_ = __h;
-
-            // Lazily construct the __exception_ member here now that we
-            // know it will be used as a nested generator. This will be
-            // destroyed by the promise destructor.
-            __nested.__exception_.construct();
             __root.__parentOrLeaf_ = __gen_.__get_coro();
 
             // Immediately resume the nested coroutine (nested generator)
@@ -452,9 +386,11 @@ struct __generator_promise_base
         }
 
         void await_resume() {
-            __generator_promise_base& __nestedPromise = *__gen_.__get_promise();
-            if (__nestedPromise.__exception_.get()) {
-                std::rethrow_exception(std::move(__nestedPromise.__exception_.get()));
+            if (__gen_.__get_coro()) {
+                __generator_promise_base& __nestedPromise = *__gen_.__get_promise();
+                if (__nestedPromise.__exception_) {
+                    std::rethrow_exception(std::move(__nestedPromise.__exception_));
+                }
             }
         }
     };
@@ -571,9 +507,6 @@ public:
 
     ~generator() noexcept {
         if (__coro_) {
-            if (__started_ && !__coro_.done()) {
-                __coro_.promise().__value_.destruct();
-            }
             __coro_.destroy();
         }
     }
@@ -618,7 +551,6 @@ public:
         }
 
         iterator &operator++() {
-            __coro_.promise().__value_.destruct();
             __coro_.promise().resume();
             return *this;
         }
@@ -627,7 +559,7 @@ public:
         }
 
         reference operator*() const noexcept {
-            return static_cast<reference>(__coro_.promise().__value_.get());
+            return static_cast<reference>(*__coro_.promise().__value_);
         }
 
       private:
@@ -671,7 +603,7 @@ class generator<_Ref, _Value, use_allocator_arg> {
     using __promise_base = __generator_promise_base<_Ref>;
 public:
 
-    generator() noexcept 
+    generator() noexcept
         : __promise_(nullptr)
         , __coro_()
         , __started_(false)
@@ -685,9 +617,6 @@ public:
 
     ~generator() noexcept {
         if (__coro_) {
-            if (__started_ && !__coro_.done()) {
-                __promise_->__value_.destruct();
-            }
             __coro_.destroy();
         }
     }
@@ -734,7 +663,6 @@ public:
         }
 
         iterator& operator++() {
-            __promise_->__value_.destruct();
             __promise_->resume();
             return *this;
         }
@@ -744,7 +672,7 @@ public:
         }
 
         reference operator*() const noexcept {
-            return static_cast<reference>(__promise_->__value_.get());
+            return static_cast<reference>(*__promise_->__value_);
         }
 
       private:

--- a/include/__generator.hpp
+++ b/include/__generator.hpp
@@ -377,7 +377,8 @@ struct __generator_promise_base
     using __reference = __generator_reference_type_t<_Ref>;
     using __reference_decayed = std::remove_cvref_t<__reference>;
 
-    std::suspend_always yield_value(__reference_decayed & __x) noexcept {
+    std::suspend_always yield_value(__reference_decayed & __x) noexcept
+    requires (!std::is_const_v<std::remove_reference_t<__reference>>) {
         if constexpr (__is_cheap) {
             __root_->__value_ = __x;
         }
@@ -397,8 +398,7 @@ struct __generator_promise_base
         return {};
     }
 
-    std::suspend_always yield_value(const __reference_decayed & __x) noexcept
-    requires (std::is_const_v<std::remove_reference_t<__reference>>){
+    std::suspend_always yield_value(const __reference_decayed & __x) noexcept {
         if constexpr (__is_cheap) {
             __root_->__value_ = __x;
         }

--- a/include/__generator.hpp
+++ b/include/__generator.hpp
@@ -197,14 +197,15 @@ constexpr size_t __aligned_allocation_size(size_t s, size_t a) {
 
 
 template <typename _Type>
-using __generator_reference_type_t = std::add_lvalue_reference_t<
-std::conditional_t<std::is_copy_constructible_v<_Type>, std::add_const_t<_Type>, _Type>>;
+using __generator_reference_type_t = std::conditional_t<
+    std::is_object_v<_Type>,
+    std::add_lvalue_reference_t<std::add_const_t<_Type>>, _Type>;
 
 template <typename _Type>
-using __default_generator_value_type_t = std::__remove_cvref_t<__generator_reference_type_t<_Type>>;
+using __default_generator_value_type_t = std::remove_cvref_t<__generator_reference_type_t<_Type>>;
 
-template <typename _Ref>
-using __generator_storage_type_t = __default_generator_value_type_t<_Ref>;
+template <typename _Type>
+using __generator_storage_type_t = std::remove_reference_t<__generator_reference_type_t<_Type>>;
 
 
 template <typename _Ref,
@@ -326,26 +327,28 @@ struct __generator_promise_base
         return {};
     }
 
+    using __reference = __generator_reference_type_t<_Ref>;
 
-    std::suspend_always yield_value(const __generator_storage_type_t<_Ref> & __x)
-    requires std::convertible_to<const __generator_storage_type_t<_Ref> &, __generator_reference_type_t<_Ref>>
-    {
+    std::suspend_always yield_value(__reference __x) noexcept
+    requires std::is_lvalue_reference_v<__reference> {
         __root_->__value_ = std::addressof(__x);
         return {};
     }
 
-    std::suspend_always yield_value(__generator_storage_type_t<_Ref> & __x)
-    requires std::convertible_to<__generator_storage_type_t<_Ref> &, __generator_reference_type_t<_Ref>> {
+    std::suspend_always yield_value(std::remove_const_t<__reference> __x) noexcept
+    requires std::is_lvalue_reference_v<__reference> && std::is_const_v<__reference>{
         __root_->__value_ = std::addressof(__x);
         return {};
     }
 
     template <typename T>
+    requires (is_constructible_v<__generator_storage_type_t<_Ref>, T>)
     auto yield_value(T&& __x)
-    noexcept(std::is_nothrow_constructible_v<__generator_storage_type_t<_Ref>, T&&>)
-    requires is_constructible_v<__generator_storage_type_t<_Ref>, T&&> &&
-        std::convertible_to<__generator_storage_type_t<_Ref> &, __generator_reference_type_t<_Ref>>
-    {
+    noexcept(std::is_nothrow_constructible_v<__generator_storage_type_t<_Ref>, T>) {
+
+        static_assert(std::is_nothrow_convertible_v<__generator_storage_type_t<_Ref>,
+                __generator_reference_type_t<_Ref>>);
+
         struct awaiter : std::suspend_always {
             __generator_storage_type_t<_Ref> __value;
             std::exception_ptr __exception;

--- a/include/__generator.hpp
+++ b/include/__generator.hpp
@@ -229,7 +229,7 @@ constexpr size_t __aligned_allocation_size(size_t s, size_t a) {
 
 template <typename _Type>
 using __generator_reference_type_t = std::conditional_t<
-    std::is_object_v<_Type>,
+    !std::is_reference<_Type>::value,
     std::add_lvalue_reference_t<std::add_const_t<_Type>>, _Type>;
 
 template <typename _Type>
@@ -366,22 +366,17 @@ struct __generator_promise_base
 
     using __reference = __generator_reference_type_t<_Ref>;
 
-    std::suspend_always yield_value(__reference __x) noexcept
-    requires std::is_lvalue_reference_v<__reference> {
+    template <typename T = __reference>
+    requires (std::same_as<std::remove_cvref_t<__reference>, std::remove_cvref_t<T>> && (
+        std::is_const_v<std::remove_reference_t<__reference>> ||
+        (std::is_lvalue_reference_v<__reference> == std::is_lvalue_reference_v<T>)))
+    std::suspend_always yield_value(T&& __x) noexcept  {
         __root_->__value_ = std::addressof(__x);
         return {};
     }
-
-    std::suspend_always yield_value(std::remove_const_t<__reference> __x) noexcept
-    requires std::is_lvalue_reference_v<__reference> && std::is_const_v<__reference>{
-        __root_->__value_ = std::addressof(__x);
-        return {};
-    }
-
-
 
     template <typename T>
-    requires (is_constructible_v<__generator_storage_type_t<_Ref>, T>) && (!std::same_as<std::remove_cvref_t<__reference>, T>)
+    requires (is_constructible_v<__generator_storage_type_t<_Ref>, T&&>) && (!std::same_as<std::remove_cvref_t<__reference>,  std::remove_cvref_t<T>>)
     auto yield_value(T&& __x)
     noexcept(std::is_nothrow_constructible_v<__generator_storage_type_t<_Ref>, T>) {
 

--- a/include/__generator.hpp
+++ b/include/__generator.hpp
@@ -197,9 +197,10 @@ constexpr size_t __aligned_allocation_size(size_t s, size_t a) {
 
 
 template <typename _Type>
-using __generator_reference_type_t = std::add_lvalue_reference_t<std::add_const_t<_Type>>;
-template <typename _Type>
+using __generator_reference_type_t = std::add_lvalue_reference_t<
+std::conditional_t<std::is_copy_constructible_v<_Type>, std::add_const_t<_Type>, _Type>>;
 
+template <typename _Type>
 using __default_generator_value_type_t = std::__remove_cvref_t<__generator_reference_type_t<_Type>>;
 
 template <typename _Ref>
@@ -332,16 +333,18 @@ struct __generator_promise_base
         __root_->__value_ = std::addressof(__x);
         return {};
     }
-    std::suspend_always yield_value(__generator_storage_type_t<_Ref> & __x) {
+
+    std::suspend_always yield_value(__generator_storage_type_t<_Ref> & __x)
+    requires std::convertible_to<__generator_storage_type_t<_Ref> &, __generator_reference_type_t<_Ref>> {
         __root_->__value_ = std::addressof(__x);
         return {};
     }
 
     template <typename T>
     auto yield_value(T&& __x)
-    noexcept(std::is_nothrow_constructible_v<__generator_storage_type_t<_Ref>, T>)
-    requires is_constructible_v<__generator_storage_type_t<_Ref>, T> &&
-        std::convertible_to<const __generator_storage_type_t<_Ref> &, __generator_reference_type_t<_Ref>>
+    noexcept(std::is_nothrow_constructible_v<__generator_storage_type_t<_Ref>, T&&>)
+    requires is_constructible_v<__generator_storage_type_t<_Ref>, T&&> &&
+        std::convertible_to<__generator_storage_type_t<_Ref> &, __generator_reference_type_t<_Ref>>
     {
         struct awaiter : std::suspend_always {
             __generator_storage_type_t<_Ref> __value;

--- a/include/__generator.hpp
+++ b/include/__generator.hpp
@@ -14,7 +14,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <memory>
-#pragma once
 
 #if __has_include(<coroutine>)
 #include <coroutine>
@@ -142,7 +141,39 @@ concept range = requires(_T& __t) {
 
 namespace std {
 
-struct use_allocator_arg {};
+template <typename _T>
+class __manual_lifetime {
+  public:
+    __manual_lifetime() noexcept {}
+    ~__manual_lifetime() {}
+
+    template <typename... _Args>
+    _T& construct(_Args&&... __args) noexcept(std::is_nothrow_constructible_v<_T, _Args...>) {
+        return *::new (static_cast<void*>(std::addressof(__value_))) _T((_Args&&)__args...);
+    }
+
+    void destruct() noexcept(std::is_nothrow_destructible_v<_T>) {
+        __value_.~_T();
+    }
+
+    _T& get() & noexcept {
+        return __value_;
+    }
+    _T&& get() && noexcept {
+        return static_cast<_T&&>(__value_);
+    }
+    const _T& get() const & noexcept {
+        return __value_;
+    }
+    const _T&& get() const && noexcept {
+        return static_cast<const _T&&>(__value_);
+    }
+
+  private:
+    union {
+        std::remove_const_t<_T> __value_;
+    };
+};
 
 struct use_allocator_arg {};
 
@@ -276,7 +307,7 @@ struct __generator_promise_base
 
     __generator_promise_base* __root_;
     std::coroutine_handle<> __parentOrLeaf_;
-    std::exception_ptr __exception_;
+    __manual_lifetime<std::exception_ptr> __exception_;
     std::add_pointer_t<__generator_storage_type_t<_Ref>> __value_;
 
     explicit __generator_promise_base(std::coroutine_handle<> thisCoro) noexcept
@@ -285,6 +316,12 @@ struct __generator_promise_base
     {}
 
     ~__generator_promise_base() {
+        if (__root_ != this) [[unlikely]] {
+            // This coroutine was used as a nested generator and so will
+            // have constructed its __exception_ member which needs to be
+            // destroyed here.
+            __exception_.destruct();
+        }
     }
 
     std::suspend_always initial_suspend() noexcept {
@@ -294,8 +331,8 @@ struct __generator_promise_base
     void return_void() noexcept {}
 
     void unhandled_exception() {
-        if (__root_ != this) {
-            __exception_ = std::current_exception();
+        if (__root_ != this)  [[unlikely]]  {
+            __exception_.get() = std::current_exception();
         } else {
             throw;
         }
@@ -341,8 +378,10 @@ struct __generator_promise_base
         return {};
     }
 
+
+
     template <typename T>
-    requires (is_constructible_v<__generator_storage_type_t<_Ref>, T>)
+    requires (is_constructible_v<__generator_storage_type_t<_Ref>, T>) && (!std::same_as<std::remove_cvref_t<__reference>, T>)
     auto yield_value(T&& __x)
     noexcept(std::is_nothrow_constructible_v<__generator_storage_type_t<_Ref>, T>) {
 
@@ -351,7 +390,6 @@ struct __generator_promise_base
 
         struct awaiter : std::suspend_always {
             __generator_storage_type_t<_Ref> __value;
-            std::exception_ptr __exception;
 
 
             awaiter(__generator_promise_base* __this, T&& __t) : __value((T&&)__t) {
@@ -360,11 +398,7 @@ struct __generator_promise_base
             awaiter(const awaiter&&) = delete;
             awaiter(awaiter&&) = delete;
 
-            void await_resume() {
-                if (__exception) {
-                    std::rethrow_exception(std::move(__exception));
-                }
-            }
+            void await_resume() noexcept{}
         };
         return awaiter(this, (T&&)(__x));
     };
@@ -391,9 +425,9 @@ struct __generator_promise_base
             __generator_promise_base& __current = __h.promise();
             __generator_promise_base& __nested = *__gen_.__get_promise();
             __generator_promise_base& __root = *__current.__root_;
-
             __nested.__root_ = __current.__root_;
             __nested.__parentOrLeaf_ = __h;
+            __nested.__exception_.construct();
             __root.__parentOrLeaf_ = __gen_.__get_coro();
 
             // Immediately resume the nested coroutine (nested generator)
@@ -403,8 +437,8 @@ struct __generator_promise_base
         void await_resume() {
             if (__gen_.__get_coro()) {
                 __generator_promise_base& __nestedPromise = *__gen_.__get_promise();
-                if (__nestedPromise.__exception_) {
-                    std::rethrow_exception(std::move(__nestedPromise.__exception_));
+                if (__nestedPromise.__exception_.get()) {
+                    std::rethrow_exception(std::move(__nestedPromise.__exception_.get()));
                 }
             }
         }

--- a/include/__generator.hpp
+++ b/include/__generator.hpp
@@ -196,8 +196,18 @@ constexpr size_t __aligned_allocation_size(size_t s, size_t a) {
 }
 
 
+template <typename _Type>
+using __generator_reference_type_t = std::add_lvalue_reference_t<std::add_const_t<_Type>>;
+template <typename _Type>
+
+using __default_generator_value_type_t = std::__remove_cvref_t<__generator_reference_type_t<_Type>>;
+
+template <typename _Ref>
+using __generator_storage_type_t = __default_generator_value_type_t<_Ref>;
+
+
 template <typename _Ref,
-          typename _Value = std::remove_cvref_t<_Ref>,
+          typename _Value     = __default_generator_value_type_t<_Ref>,
           typename _Allocator = use_allocator_arg>
 class generator;
 
@@ -264,13 +274,8 @@ struct __generator_promise_base
 
     __generator_promise_base* __root_;
     std::coroutine_handle<> __parentOrLeaf_;
-    // Note: Using manual_lifetime here to avoid extra calls to exception_ptr
-    // constructor/destructor in cases where it is not needed (i.e. where this
-    // generator coroutine is not used as a nested coroutine).
-    // This member is lazily constructed by the __yield_sequence_awaiter::await_suspend()
-    // method if this generator is used as a nested generator.
     std::exception_ptr __exception_;
-    std::add_pointer_t<std::remove_reference_t<_Ref>> __value_;
+    std::add_pointer_t<__generator_storage_type_t<_Ref>> __value_;
 
     explicit __generator_promise_base(std::coroutine_handle<> thisCoro) noexcept
         : __root_(this)
@@ -321,21 +326,25 @@ struct __generator_promise_base
     }
 
 
-    std::suspend_always yield_value(_Ref __x)
-    requires std::is_lvalue_reference_v<_Ref>
+    std::suspend_always yield_value(const __generator_storage_type_t<_Ref> & __x)
+    requires std::convertible_to<const __generator_storage_type_t<_Ref> &, __generator_reference_type_t<_Ref>>
     {
+        __root_->__value_ = std::addressof(__x);
+        return {};
+    }
+    std::suspend_always yield_value(__generator_storage_type_t<_Ref> & __x) {
         __root_->__value_ = std::addressof(__x);
         return {};
     }
 
     template <typename T>
     auto yield_value(T&& __x)
-    noexcept(std::is_nothrow_constructible_v<_Ref, T>)
-    requires is_constructible_v<_Ref, T>
-
+    noexcept(std::is_nothrow_constructible_v<__generator_storage_type_t<_Ref>, T>)
+    requires is_constructible_v<__generator_storage_type_t<_Ref>, T> &&
+        std::convertible_to<const __generator_storage_type_t<_Ref> &, __generator_reference_type_t<_Ref>>
     {
         struct awaiter : std::suspend_always {
-            std::remove_reference_t<_Ref> __value;
+            __generator_storage_type_t<_Ref> __value;
             std::exception_ptr __exception;
 
 
@@ -528,7 +537,7 @@ public:
         using iterator_category = std::input_iterator_tag;
         using difference_type = std::ptrdiff_t;
         using value_type = _Value;
-        using reference = _Ref;
+        using reference  = __generator_reference_type_t<_Ref>;
         using pointer = std::add_pointer_t<_Ref>;
 
         iterator() noexcept = default;
@@ -639,8 +648,8 @@ public:
         using iterator_category = std::input_iterator_tag;
         using difference_type = std::ptrdiff_t;
         using value_type = _Value;
-        using reference = _Ref;
-        using pointer = std::add_pointer_t<_Ref>;
+        using reference  = __generator_reference_type_t<_Ref>;
+        using pointer    = std::add_pointer_t<__generator_storage_type_t<_Ref>>;
 
         iterator() noexcept = default;
         iterator(const iterator &) = delete;

--- a/tests/nested_test.cpp
+++ b/tests/nested_test.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 #include <memory>
 #include <exception>
+#include <atomic>
 
 #include "check.hpp"
 

--- a/tests/nested_test.cpp
+++ b/tests/nested_test.cpp
@@ -257,11 +257,11 @@ void test_nested_generator_scopes_exit_innermost_scope_first() {
             scope_guard g{[&] { events.push_back(4); }};
 
             co_yield 42;
-        }();
+        };
 
         scope_guard h{[&] { events.push_back(5); }};
 
-        co_yield std::ranges::elements_of(std::move(nested));
+        co_yield std::ranges::elements_of(std::move(nested()));
     };
 
     {

--- a/tests/simple_test.cpp
+++ b/tests/simple_test.cpp
@@ -88,9 +88,7 @@ void test_range_based_for_loop_2() {
         static_assert(std::is_same_v<decltype(x), const X&>);
 
         // 1. temporary in co_yield expression
-        // 2. reference value stored in promise
-        // 3. iteration variable
-        CHECK(count == 2);
+        CHECK(count == 1);
         ++elementCount;
     }
 
@@ -122,8 +120,7 @@ void test_range_based_for_loop_3() {
         static_assert(std::is_same_v<decltype(x), const X&>);
 
         // 1. temporary in co_yield expression
-        // 2. move inside awaiter
-        CHECK(count == 2);
+        CHECK(count == 1);
         ++elementCount;
     }
 

--- a/tests/simple_test.cpp
+++ b/tests/simple_test.cpp
@@ -170,6 +170,40 @@ void test_dereference_iterator_copies_reference() {
     CHECK(ctorCount == dtorCount);
 }
 
+void test_move_only_types() {
+    struct move_only {
+        move_only() = default;
+        move_only(const move_only&) = delete;
+        move_only(move_only&&) = default;
+    };
+
+    auto g = []() -> std::generator<move_only> {
+        co_yield move_only{};
+    }();
+
+    for(auto&& x : g) {
+        static_assert(std::same_as<decltype(x), move_only&>, "move only types should produce a mutable reference type");
+        auto y = std::move(x);
+    }
+}
+
+void test_immovable_types() {
+    struct immovable {
+        immovable() = default;
+        immovable(const immovable&) = delete;
+        immovable(immovable&&) = delete;
+    };
+
+    auto g = []() -> std::generator<immovable> {
+        immovable i;
+        co_yield i;
+    }();
+
+    for(auto&& x : g) {
+        static_assert(std::same_as<decltype(x), immovable&>, "immovable types should produce a mutable reference type");
+    }
+}
+
 int main() {
     RUN(test_default_constructor);
     RUN(test_empty_generator);
@@ -178,5 +212,7 @@ int main() {
     RUN(test_range_based_for_loop_2);
     RUN(test_range_based_for_loop_3);
     RUN(test_dereference_iterator_copies_reference);
+    RUN(test_move_only_types);
+    RUN(test_immovable_types);
     return 0;
 }

--- a/tests/simple_test.cpp
+++ b/tests/simple_test.cpp
@@ -14,10 +14,10 @@
 // Check some basic properties of the type at compile-time.
 
 // A generator should be a 'range'
-static_assert(std::ranges::range<std::generator<int>>);
+//static_assert(std::ranges::range<std::generator<int>>);
 
 // A generator should also be a 'view'
-static_assert(std::ranges::view<std::generator<int>>);
+//static_assert(std::ranges::view<std::generator<int>>);
 
 //
 static_assert(std::is_same_v<
@@ -174,16 +174,21 @@ void test_move_only_types() {
     struct move_only {
         move_only() = default;
         move_only(const move_only&) = delete;
-        move_only(move_only&&) = default;
+        move_only(move_only&& other) {other.i = 0;};
+
+        int i = 42;
     };
 
-    auto g = []() -> std::generator<move_only> {
+    auto g = []() -> std::generator<move_only&&> {
         co_yield move_only{};
     }();
 
     for(auto&& x : g) {
-        static_assert(std::same_as<decltype(x), move_only&>, "move only types should produce a mutable reference type");
+        static_assert(std::same_as<decltype(x), move_only&&>);
+        // We should not perform any actual move
+        CHECK(x.i == 42);
         auto y = std::move(x);
+        CHECK(x.i == 0);
     }
 }
 
@@ -194,12 +199,12 @@ void test_immovable_types() {
         immovable(immovable&&) = delete;
     };
 
-    auto g = []() -> std::generator<immovable> {
+    auto g = []() -> std::generator<immovable&> {
         immovable i;
         co_yield i;
     }();
 
-    for(auto&& x : g) {
+    for(auto& x : g) {
         static_assert(std::same_as<decltype(x), immovable&>, "immovable types should produce a mutable reference type");
     }
 }

--- a/tests/simple_test.cpp
+++ b/tests/simple_test.cpp
@@ -19,7 +19,7 @@ static_assert(std::ranges::range<std::generator<int>>);
 // A generator should also be a 'view'
 static_assert(std::ranges::view<std::generator<int>>);
 
-// 
+//
 static_assert(std::is_same_v<
     std::ranges::range_reference_t<std::generator<const std::string&>>,
     const std::string&>);


### PR DESCRIPTION
Hey Lewis.


- When yielding a reference, we store a pointer to that reference, otherwise, we store the constructed value in an awaiter, which gives copy reference yielding - which is the part of Mathias suggestion that I really liked
- The reference type is deduced from the first parameter (still called `_Ref`) as discussed on discord

```
 T => const T&
 T& => T&
 const T& => const T&
 T&& => T&&
 const T& => const T&
 ```
