### PR TITLE
Remove support for iterating over a default-constructed generator

### DIFF
--- a/tests/nested_test.cpp
+++ b/tests/nested_test.cpp
@@ -14,24 +14,6 @@
 
 #include "check.hpp"
 
-void test_yielding_elements_of_default_constructed_generator() {
-    bool started = false;
-    bool finished = false;
-    auto makeGen = [&]() -> std::generator<int> {
-        started = true;
-        co_yield std::ranges::elements_of(std::generator<int>{});
-        finished = true;
-    };
-
-    auto gen = makeGen();
-    CHECK(!started);
-    CHECK(!finished);
-    auto it = gen.begin();
-    CHECK(started);
-    CHECK(finished);
-    CHECK(it == gen.end());
-}
-
 void test_yielding_elements_of_empty_generator() {
     bool started1 = false;
     bool started2 = false;
@@ -319,7 +301,6 @@ void test_exception_propagating_from_nested_generator() {
 }
 
 int main() {
-    RUN(test_yielding_elements_of_default_constructed_generator);
     RUN(test_yielding_elements_of_empty_generator);
     RUN(test_yielding_elements_of_nested_one_level);
     RUN(test_yielding_elements_of_recursive);

--- a/tests/simple_test.cpp
+++ b/tests/simple_test.cpp
@@ -29,7 +29,6 @@ static_assert(std::is_same_v<
 
 void test_default_constructor() {
     std::generator<int> g;
-    CHECK(g.begin() == g.end());
 }
 
 void test_empty_generator() {


### PR DESCRIPTION
This removes the need for some conditional checks for
a null coroutine_handle when iterating over the elements.

Suggested during initial review of [P2168](https://wg21.link/P2168) in LEWG.